### PR TITLE
Added BigBash to "Tools"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ List of tools and techniques for working with relational databases inspired by o
 - [SQL Fiddle](http://sqlfiddle.com/) - Easly test and share database problems and their solutions. Can use different backend DBMS's (MySQL, PostgreSQL, MS SQL Server, Oracle, and SQLite)
 - [SqlPad](http://rickbergfalk.github.io/sqlpad/) - A web app for running SQL queries and visualizing the results
 - [ERAlchemy](https://github.com/Alexis-benoist/eralchemy) - ERAlchemy generates Entity Relation (ER) diagram from databases
+- [BigBash](https://github.com/zalando/bigbash) - Open-source converter that generates a bash one-liner from an SQL Select query, no database necessary


### PR DESCRIPTION
BigBash (https://github.com/zalando/bigbash)  is an open-source converter that generates a bash one-liner from an SQL Select query, no database necessary.
