### PR TITLE
Add SQL Syntax Cheat Sheet to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ List of tools and techniques for working with relational databases inspired by o
 - [Basic and advanced concepts of SQL with examples on Scaler](https://www.scaler.com/topics/sql/) - A curated interactive space for aspiring programmers to learn and master their SQL skills.
 - [Mostly Asked SQL Interview Questions and Answers for Freshers](https://boldcoder.blogspot.com/2024/08/fresher-sql-interview-questions.html) - Online coding tutorials and Interview questions.
 - [SQL tips and tricks](https://github.com/ben-nour/SQL-tips-and-tricks) - SQL tips that cover everything from readability to common pitfalls.
+- [SQL Syntax Cheat Sheet](https://github.com/mergisi/sql-syntax-cheat-sheet) - Comprehensive SQL reference covering 20 sections: DDL, DML, JOINs, window functions, CTEs, database-specific syntax (MySQL, PostgreSQL, SQL Server), performance tips, and common mistakes.


### PR DESCRIPTION
Adds a comprehensive SQL syntax cheat sheet (20 sections, 800+ lines) covering everything from basic DDL/DML to window functions, CTEs, and database-specific syntax differences.

GitHub: https://github.com/mergisi/sql-syntax-cheat-sheet
31 stars, MIT license, actively maintained.