### PR TITLE
Add AI for Database to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [EverSQL](https://www.eversql.com/) - SQL query optimization and database observability, powered by AI.
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
+- [AI for Database](https://aifordatabase.com) - Connect to any database and query it in natural language. No SQL required — get instant insights, build self-refreshing dashboards, and trigger automated workflows on database changes. Freemium.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds [AI for Database](https://aifordatabase.com) to the Tools section.

AI for Database is an agentic AI product for databases — connect any database and query it in plain English, no SQL needed. It features self-refreshing dashboards, natural language queries, and automated workflows that trigger on database changes. Freemium pricing.