### PR TITLE
Add drift to Formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [Poor SQL](http://poorsql.com/) - Instant Free and Open-Source T-SQL Formatting (look here for the plugins and whatnot: https://github.com/TaoK/PoorMansTSqlFormatter )
 - [ExtendsClass](https://extendsclass.com/sql-formatter.html) - Online SQL formatter
 - [CodeNeat SQL Formatter](https://codeneat.dev/sql-formatter) - Privacy-first online SQL formatter supporting 7 dialects.
+- [drift](https://github.com/f4rkh4d/drift) - Multi-dialect SQL linter and formatter in Rust. 7 dialects, ~80 rules, schema-aware, single binary. Ships with LSP, pre-commit hook, GitHub Action. Live WASM playground at [drift.frkhd.com/play/](https://drift.frkhd.com/play/).
 
 ## <a name="tools"></a>Tools
 


### PR DESCRIPTION
Adding [drift](https://github.com/f4rkh4d/drift) under **Formatters**.

drift is a multi-dialect SQL linter and formatter in Rust:
- 7 dialects: postgres, mysql, sqlite, snowflake, bigquery, tsql, ansi.
- ~80 rules across 9 categories (correctness, security, schema-aware, migration, performance, portability, conventions, ambiguity, style).
- Single static binary, sub-second on thousands of files.
- Code-frame diagnostics (rustc / ruff style) with caret + inline fix hint.
- Ships with an LSP, a native pre-commit hook (`drift hook install`), and a GitHub Action.

Live demo (WASM, same engine as the CLI): https://drift.frkhd.com/play/

License: MIT. Actively maintained. One-line addition under Formatters.