### PR TITLE
Add OrcaQ to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [OrcaQ](https://github.com/cin12211/orca-q) - A modern, open-source database editor for PostgreSQL, MySQL, Redis, and more. Features an AI assistant, ERD visualizer, schema diff, and visual role management.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
    I would like to propose adding **OrcaQ** to the awesome-sql list. 
   
   It is an open-source, modern database editor with features designed
   to simplify database management:
   - Multi-database support (PostgreSQL, MySQL, Redis, etc.)
   - Built-in AI assistant
   - ERD visualizer
   - Schema diff & visual role management
Repo link: https://github.com/cin12211/orca-q
Let me know if there's anything else needed for this PR. Thanks!