### PR TITLE
Add OneQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [LINQPad](https://www.linqpad.net/) - LINQPad is not just for LINQ queries, but any C#/F#/VB expression, statement block or program.
 - [SchemaSpy](https://github.com/schemaspy/schemaspy) - we will do the best to simplify documentation process of your database
 - [MissionKontrol](https://github.com/Mission-Kontrol/MissionKontrol) - Self-hosted admin panel to manage one or more MySQL/PostGRES databases.
-- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted gateway for safe, auditable agent queries across approved data sources.
+- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted gateway for safe, auditable queries for agents across approved data sources.
 - [DBeaver](https://dbeaver.io) - Free multi-platform database tool for developers, database administrators, analysts and all people who need to work with databases. Supports all popular databases.
 - [EverSQL](https://www.eversql.com/) - SQL query optimization and database observability, powered by AI.
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [LINQPad](https://www.linqpad.net/) - LINQPad is not just for LINQ queries, but any C#/F#/VB expression, statement block or program.
 - [SchemaSpy](https://github.com/schemaspy/schemaspy) - we will do the best to simplify documentation process of your database
 - [MissionKontrol](https://github.com/Mission-Kontrol/MissionKontrol) - Self-hosted admin panel to manage one or more MySQL/PostGRES databases.
+- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted data access gateway for databases, analytics tools, and APIs, with centralized credentials, read-only query validation, query limits, and audit logs.
 - [DBeaver](https://dbeaver.io) - Free multi-platform database tool for developers, database administrators, analysts and all people who need to work with databases. Supports all popular databases.
 - [EverSQL](https://www.eversql.com/) - SQL query optimization and database observability, powered by AI.
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [LINQPad](https://www.linqpad.net/) - LINQPad is not just for LINQ queries, but any C#/F#/VB expression, statement block or program.
 - [SchemaSpy](https://github.com/schemaspy/schemaspy) - we will do the best to simplify documentation process of your database
 - [MissionKontrol](https://github.com/Mission-Kontrol/MissionKontrol) - Self-hosted admin panel to manage one or more MySQL/PostGRES databases.
-- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted data access gateway for databases, analytics tools, and APIs, with centralized credentials, read-only query validation, query limits, and audit logs.
+- [OneQuery](https://github.com/wordbricks/onequery) - Self-hosted gateway for safe, auditable agent queries across approved data sources.
 - [DBeaver](https://dbeaver.io) - Free multi-platform database tool for developers, database administrators, analysts and all people who need to work with databases. Supports all popular databases.
 - [EverSQL](https://www.eversql.com/) - SQL query optimization and database observability, powered by AI.
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features


### PR DESCRIPTION
Adds OneQuery to Tools.

OneQuery is a self-hosted gateway for safe, auditable queries for agents across approved data sources.

Guideline check:
- One link in this PR.
- Link works and no duplicate OneQuery entry was found before submission.
- Description is short, neutral, and follows the existing list format.
- Disclosure: I am affiliated with Wordbricks/OneQuery.