### PR TITLE
Add LibreDB Studio to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [LibreDB Studio](https://github.com/libredb/libredb-studio) - MIT-licensed, AI-powered open source SQL IDE that connects to PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis directly from the browser.
 
 ## <a name="resources"></a>Resources
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
-- [LibreDB Studio](https://github.com/libredb/libredb-studio) - MIT-licensed, AI-powered open source SQL IDE that connects to PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis directly from the browser.
+- [LibreDB Studio](https://github.com/libredb/libredb-studio) - MIT-licensed, AI-powered open-source SQL IDE that connects to PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis directly from the browser.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
This PR adds **LibreDB Studio** to the Tools section.

LibreDB Studio is an MIT-licensed, AI-powered open source SQL IDE that connects to PostgreSQL, MySQL, Oracle, SQL Server, SQLite, MongoDB and Redis directly from the browser. It fits alongside existing tools such as WhoDB and ThalamusDB.

Links:
- GitHub: https://github.com/libredb/libredb-studio
- Website: https://libredb.org/