### PR TITLE
Add sqllens to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [sqllens](https://github.com/NiclasOlofsson/sqllens) - TypeScript SQL parser and static analyzer: AST, name resolution, type inference, and column-level lineage. Supports Databricks, T-SQL, Snowflake, BigQuery, Redshift, PostgreSQL, DuckDB, Trino, SQLite, and MySQL. Error-tolerant for editor tooling.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds sqllens, a TypeScript SQL parser and static analyzer: AST, name resolution, type inference, and column-level lineage across Databricks, T-SQL, Snowflake, BigQuery, Redshift, PostgreSQL, DuckDB, Trino, SQLite, and MySQL. MIT, on npm. Disclosure: I am the author.