### PR TITLE
Add Foxschema to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [Foxschema](https://foxschema.com) - Compares PostgreSQL schemas and generates database migrations, available as a web app, desktop app, or self-hosted.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
## Summary
- Adds [Foxschema](https://foxschema.com) to the Tools section — compares PostgreSQL schemas and generates database migrations, available as a web app, desktop app, or self-hosted.
