### PR TITLE
Add sqlike to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [sqlike](https://github.com/orifisher2/sqlike) - Deterministic SQL analyzer and query-equivalence checker (anti-patterns, rewrites, index advice) for Postgres, MySQL, SQLite, and SQL Server. Web, CLI, and MCP.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds [sqlike](https://github.com/orifisher2/sqlike) to the Tools section. sqlike is a deterministic SQL static analyzer and query-equivalence checker (no AI in the analysis engine): it reports anti-patterns, suggests auto-rewrites and index advice, and its `diff` checks whether two queries are equivalent, for Postgres, MySQL, SQLite, and SQL Server. Available as a web app, CLI, and MCP server.
