### PR TITLE
Add SchemaSmith

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [Flyway](https://flywaydb.org/) - Database migration tool
 - [Liquibase](http://www.liquibase.org/) - Source Control for your database
 - [Schema Guard RDBM](https://www.dbinvent.com/rdbm/) - Postgres database migration tool, plain-SQL, and declarative definition supported
+- [SchemaSmith](https://github.com/Schema-Smith/SchemaSmith) - State-based, declarative schema management for SQL Server, PostgreSQL, MySQL, and MariaDB.
 - [PgCLI](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting
 - [LINQPad](https://www.linqpad.net/) - LINQPad is not just for LINQ queries, but any C#/F#/VB expression, statement block or program.
 - [SchemaSpy](https://github.com/schemaspy/schemaspy) - we will do the best to simplify documentation process of your database


### PR DESCRIPTION
Adds SchemaSmith to **Tools** (alongside Flyway/Liquibase). Free, source-available (SSCL v2.0) state-based, declarative schema management for SQL Server, PostgreSQL, MySQL, and MariaDB.