### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [Varan](https://varan.cloud) - Cross-source SQL client that joins PostgreSQL, MySQL, DuckDB and spreadsheet files in a single query also supporting Data versioning and Rollback.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds Varan, a desktop SQL client built on a local-first DuckDB engine that runs one query across PostgreSQL, MySQL, DuckDB and CSV/Excel files. Placed alphabetically in the <section name> section. Thanks for maintaining this list!