### PR TITLE
Add Stackiox SQL Formatter to Formatters section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [Poor SQL](http://poorsql.com/) - Instant Free and Open-Source T-SQL Formatting (look here for the plugins and whatnot: https://github.com/TaoK/PoorMansTSqlFormatter )
 - [ExtendsClass](https://extendsclass.com/sql-formatter.html) - Online SQL formatter
 - [CodeNeat SQL Formatter](https://codeneat.dev/sql-formatter) - Privacy-first online SQL formatter supporting 7 dialects.
+- [Stackiox SQL Formatter](https://stackiox.com/sql-formatter/) - Free online SQL formatter supporting MySQL, PostgreSQL, SQLite, T-SQL, and BigQuery with configurable keyword casing and indentation. Client-side, no signup.
 
 ## <a name="tools"></a>Tools
 


### PR DESCRIPTION
Adds [Stackiox SQL Formatter](https://stackiox.com/sql-formatter/) to the Formatters section.

- Free online SQL formatter and beautifier
- Supports 6 dialects: Standard SQL, MySQL, PostgreSQL, SQLite, T-SQL, and BigQuery
- Configurable keyword casing (uppercase/lowercase/preserve) and indent size (2/4 spaces)
- Runs entirely client-side — no data sent to any server
- No signup, no ads, no rate limits