### PR TITLE
Add provensql to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [provensql](https://github.com/nac7/provensql) - Decides whether two SQL queries are equivalent — EQUIVALENT (proven), DIFFERENT (with a runnable counterexample row), SCHEMA_CHANGE, or UNKNOWN. Sound by construction: never a false EQUIVALENT. Catches rewrites that diverge under IEEE-754 rounding and runtime-error semantics.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds **provensql** to the Tools section.

provensql decides whether two SQL queries are equivalent — EQUIVALENT (proven), DIFFERENT (with a runnable counterexample row), SCHEMA_CHANGE, or UNKNOWN. It is sound by construction (never a false EQUIVALENT) and additionally catches rewrites that diverge under IEEE-754 rounding and runtime-error semantics.

- Repo: https://github.com/nac7/provensql
- Install: `pip install provensql`
- License: Apache-2.0