### PR TITLE
Add Bytebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [BigBash](https://github.com/zalando/bigbash) - Open-source converter that generates a bash one-liner from an SQL Select query, no database necessary
 - [Flyway](https://flywaydb.org/) - Database migration tool
 - [Liquibase](http://www.liquibase.org/) - Source Control for your database
-- [Bytebase](https://www.bytebase.com/) - Database DevOps with a GitOps migration workflow, SQL review, access control, and a full API
+- [Bytebase](https://www.bytebase.com/) - Database governance platform: UI-driven or GitOps workflow, SQL review, access control, and a full API
 - [Schema Guard RDBM](https://www.dbinvent.com/rdbm/) - Postgres database migration tool, plain-SQL, and declarative definition supported
 - [PgCLI](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting
 - [LINQPad](https://www.linqpad.net/) - LINQPad is not just for LINQ queries, but any C#/F#/VB expression, statement block or program.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [BigBash](https://github.com/zalando/bigbash) - Open-source converter that generates a bash one-liner from an SQL Select query, no database necessary
 - [Flyway](https://flywaydb.org/) - Database migration tool
 - [Liquibase](http://www.liquibase.org/) - Source Control for your database
-- [Bytebase](https://www.bytebase.com/) - Database DevOps tool for schema migration, SQL review, and access control
+- [Bytebase](https://www.bytebase.com/) - Database DevOps with a GitOps migration workflow, SQL review, access control, and a full API
 - [Schema Guard RDBM](https://www.dbinvent.com/rdbm/) - Postgres database migration tool, plain-SQL, and declarative definition supported
 - [PgCLI](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting
 - [LINQPad](https://www.linqpad.net/) - LINQPad is not just for LINQ queries, but any C#/F#/VB expression, statement block or program.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [BigBash](https://github.com/zalando/bigbash) - Open-source converter that generates a bash one-liner from an SQL Select query, no database necessary
 - [Flyway](https://flywaydb.org/) - Database migration tool
 - [Liquibase](http://www.liquibase.org/) - Source Control for your database
-- [Bytebase](https://www.bytebase.com/) - Database governance platform: UI-driven or GitOps workflow, SQL review, access control, and a full API
+- [Bytebase](https://www.bytebase.com/) - The standard for database governance: SQL review, version-controlled schema changes, access control (JIT/masking), and audit logging
 - [Schema Guard RDBM](https://www.dbinvent.com/rdbm/) - Postgres database migration tool, plain-SQL, and declarative definition supported
 - [PgCLI](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting
 - [LINQPad](https://www.linqpad.net/) - LINQPad is not just for LINQ queries, but any C#/F#/VB expression, statement block or program.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [BigBash](https://github.com/zalando/bigbash) - Open-source converter that generates a bash one-liner from an SQL Select query, no database necessary
 - [Flyway](https://flywaydb.org/) - Database migration tool
 - [Liquibase](http://www.liquibase.org/) - Source Control for your database
+- [Bytebase](https://www.bytebase.com/) - Database DevOps tool for schema migration, SQL review, and access control
 - [Schema Guard RDBM](https://www.dbinvent.com/rdbm/) - Postgres database migration tool, plain-SQL, and declarative definition supported
 - [PgCLI](https://github.com/dbcli/pgcli) - Postgres CLI with autocompletion and syntax highlighting
 - [LINQPad](https://www.linqpad.net/) - LINQPad is not just for LINQ queries, but any C#/F#/VB expression, statement block or program.


### PR DESCRIPTION
Adds [Bytebase](https://github.com/bytebase/bytebase) next to Flyway and Liquibase.

Bytebase is a database governance platform — change management, access control, and audit/compliance as one system — with **two workflows**:

- **UI-driven** — create and review the change in the Bytebase console, no repo required.
- **GitOps** — migration files live in the repo, land through a PR, and Bytebase applies them and tracks revisions. Supports both **versioned** (SQL files) and **declarative** (SDL, DDL diffed and generated from a target schema) migrations.

Beyond the migration step: SQL review rules, an approval gate before production, query-level access control and data masking for the SQL editor, and a **full API** (33 gRPC services with REST mappings — projects, databases, plans, rollouts, releases, revisions, users, roles, policies) so the whole workflow is scriptable.

~14.4k stars, actively maintained.

Happy to reword or move it if you'd rather it sat elsewhere in the list.

Disclosure: I work on Bytebase.