### PR TITLE
Add Mongrel

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [Mongrel](https://www.visorcraft.com/) - Desktop database workbench and SQL client for 30+ engines with linting, EXPLAIN, visual query builder, and schema design (proprietary, free trial).
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds [Mongrel](https://www.visorcraft.com/) to the Tools section.

Mongrel is a desktop database workbench and SQL client (Windows, macOS, Linux) covering 30+ database engines, with SQL linting, visual EXPLAIN, a visual query builder, and schema design.

Licensing note: Mongrel is proprietary/paid software with a 7-day free trial. The list already includes commercial tools (e.g. DBeaver, LINQPad, EverSQL), so it appears to fit; happy to close if the list is open-source only.