### PR TITLE
Add Bruin to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [Bruin](https://github.com/bruin-data/bruin) - CLI that runs SQL and Python data pipelines with built-in data quality checks across BigQuery, Snowflake, Postgres, DuckDB and more
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds [Bruin](https://github.com/bruin-data/bruin) to the **Tools** section.

Bruin is an Apache-2.0 command-line tool for building data pipelines out of SQL and Python. Relevant to this list because the pipelines are written as plain SQL files against relational databases — BigQuery, Snowflake, Postgres, Redshift, MS SQL Server, DuckDB, ClickHouse and others — with column-level quality checks, dependency resolution, and Jinja templating on top.

Go, ~1.7k stars, actively maintained.

Entry appended to the end of Tools, matching the existing `- [name](url) - description` format. Not already listed; no prior PR for it.

Disclosure: I work on Bruin.