### PR TITLE
Add DBTool to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [DBTool](https://github.com/achi777/db-tool) - Free open-source desktop client for PostgreSQL, MySQL, MariaDB, SQLite, Oracle and SQL Server, with server-side pagination, a drag-to-join visual query builder and ER diagrams. Windows, macOS and Linux.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds **DBTool** to the Tools section.

[DBTool](https://github.com/achi777/db-tool) is a free, open-source (AGPL-3.0) desktop database client covering PostgreSQL, MySQL, MariaDB, SQLite, Oracle and Microsoft SQL Server behind one interface, with native builds for Windows, macOS and Linux.

Relative to DBeaver, which is already listed: a smaller surface, true server-side pagination (ordering, counting and paging happen in the database rather than the client), a drag-to-join visual query builder that generates the `SELECT`, a visual table designer with live DDL preview, and editable ER diagrams. No telemetry and no account; connection passwords go to the OS keychain.

I am the author of this project.
