### PR TITLE
Add stackql to SQL tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [stackql](https://github.com/stackql/stackql) - Open-source SQL query engine for querying cloud APIs across AWS, GCP, Azure, and other providers.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds stackql to the Tools section.

stackql is an open-source SQL query engine for querying cloud APIs across AWS, GCP, Azure, and other providers through a common SQL interface.

Repository: https://github.com/stackql/stackql
Documentation: https://stackql.io