### PR TITLE
Add 1bench to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [WhoDB](https://github.com/clidey/whodb) - SQL/NoSQL/Graph/Cache/Object data explorer with AI-powered chat + other useful features
 - [ThalamusDB](https://github.com/itrummer/thalamusdb) - SQL with AI operators on text, images, and sound files.
 - [SlowQL](https://github.com/makroumi/slowql) - SQL static analyzer with extensive rules for security, performance, and quality. Zero dependencies, completely offline.
+- [1bench](https://1bench.dev) - Native cross-platform desktop client for Postgres, MySQL, SQLite, ClickHouse, and two dozen other SQL and NoSQL databases.
 
 ## <a name="resources"></a>Resources
 


### PR DESCRIPTION
Adds [1bench](https://1bench.dev) to the **Tools** section.

1bench is a native cross-platform desktop client (Mac, Windows, Linux) for Postgres, MySQL, SQLite and ClickHouse, plus about two dozen other SQL and NoSQL engines, with one query editor across all of them.

Disclosure: it's a tool I build.