### PR TITLE
Add SQL Toolkit to Formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [Poor SQL](http://poorsql.com/) - Instant Free and Open-Source T-SQL Formatting (look here for the plugins and whatnot: https://github.com/TaoK/PoorMansTSqlFormatter )
 - [ExtendsClass](https://extendsclass.com/sql-formatter.html) - Online SQL formatter
 - [CodeNeat SQL Formatter](https://codeneat.dev/sql-formatter) - Privacy-first online SQL formatter supporting 7 dialects.
+- [SQL Toolkit](https://sqltoolkit.dev) - Free online SQL formatter/beautifier plus JSON, CSV, and Excel to SQL converters, a schema doc generator, and a migration risk analyzer. No signup, runs entirely in your browser.
 
 ## <a name="tools"></a>Tools
 
@@ -40,7 +41,6 @@ List of tools and techniques for working with relational databases inspired by o
 - [sql-splitter](https://github.com/HelgeSverre/sql-splitter) - CLI for splitting, merging, converting, and analyzing SQL dump files across MySQL, PostgreSQL, SQLite, and MSSQL.
 - [SQLPage](https://github.com/lovasoa/SQLpage) - Open-source SQL-only website builder
 - [PixQL](https://github.com/Phildo/pixQL) - Command-line image processing tool in SQL by @Phildo
-- [SQL Fiddle](http://sqlfiddle.com/) - Easly test and share database problems and their solutions. Supports multiple different backend DBMS's.
 - [SqlPad](http://rickbergfalk.github.io/sqlpad/) - A web app for running SQL queries and visualizing the results
 - [ERAlchemy](https://github.com/Alexis-benoist/eralchemy) - ERAlchemy generates Entity Relation (ER) diagram from databases
 - [BigBash](https://github.com/zalando/bigbash) - Open-source converter that generates a bash one-liner from an SQL Select query, no database necessary

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ List of tools and techniques for working with relational databases inspired by o
 - [sql-splitter](https://github.com/HelgeSverre/sql-splitter) - CLI for splitting, merging, converting, and analyzing SQL dump files across MySQL, PostgreSQL, SQLite, and MSSQL.
 - [SQLPage](https://github.com/lovasoa/SQLpage) - Open-source SQL-only website builder
 - [PixQL](https://github.com/Phildo/pixQL) - Command-line image processing tool in SQL by @Phildo
+- [SQL Fiddle](http://sqlfiddle.com/) - Easly test and share database problems and their solutions. Supports multiple different backend DBMS's.
 - [SqlPad](http://rickbergfalk.github.io/sqlpad/) - A web app for running SQL queries and visualizing the results
 - [ERAlchemy](https://github.com/Alexis-benoist/eralchemy) - ERAlchemy generates Entity Relation (ER) diagram from databases
 - [BigBash](https://github.com/zalando/bigbash) - Open-source converter that generates a bash one-liner from an SQL Select query, no database necessary


### PR DESCRIPTION
Adds [SQL Toolkit](https://sqltoolkit.dev) to the Formatters section.

It's a free, browser-based SQL formatter/beautifier, plus JSON/CSV/Excel to SQL converters, a schema doc generator, and a migration risk analyzer. No signup or install required, everything runs client-side.